### PR TITLE
Remove reviewers from dependabot.yml per GitHub deprecation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,8 +11,6 @@ updates:
       - dependency-type: all
     assignees:
       - tr3mor
-    reviewers:
-      - tr3mor
     labels:
       - dependencies
       - actions
@@ -25,8 +23,6 @@ updates:
     allow:
       - dependency-type: all
     assignees:
-      - tr3mor
-    reviewers:
       - tr3mor
     labels:
       - dependencies
@@ -41,8 +37,6 @@ updates:
       - dependency-type: all
     assignees:
       - tr3mor
-    reviewers:
-      - tr3mor
     labels:
       - dependencies
       - terraform
@@ -55,8 +49,6 @@ updates:
     allow:
       - dependency-type: all
     assignees:
-      - tr3mor
-    reviewers:
       - tr3mor
     labels:
       - dependencies
@@ -71,8 +63,6 @@ updates:
       - dependency-type: all
     assignees:
       - tr3mor
-    reviewers:
-      - tr3mor
     labels:
       - dependencies
       - terraform
@@ -85,8 +75,6 @@ updates:
     allow:
       - dependency-type: all
     assignees:
-      - tr3mor
-    reviewers:
       - tr3mor
     labels:
       - dependencies


### PR DESCRIPTION
## Summary
- Remove `reviewers` configuration from all package ecosystems in dependabot.yml
- GitHub is deprecating the reviewers option in favor of CODEOWNERS file (effective May 20, 2025)
- Existing CODEOWNERS file already handles review assignments

## Changes
- Removed reviewers config from 6 package ecosystems: github-actions, terraform (5 directories), and gomod
- Review assignments now handled by existing `.github/CODEOWNERS` file
- No functional change - same reviewer assignments maintained

## Test plan
- [x] Pre-commit hooks pass
- [x] Existing CODEOWNERS file verified
- [ ] Test Dependabot PR creation after merge to confirm review assignments work