### PR TITLE
Upgrade k8s chart versions to latest

### DIFF
--- a/k8s/local-cluster/apps/ingress-nginx/ingress-nginx.yaml
+++ b/k8s/local-cluster/apps/ingress-nginx/ingress-nginx.yaml
@@ -16,7 +16,7 @@ spec:
     path: ""
     chart: ingress-nginx
     repoURL: https://kubernetes.github.io/ingress-nginx
-    targetRevision: 4.5.2
+    targetRevision: 4.13.0
   syncPolicy:
     automated:
       selfHeal: true

--- a/k8s/local-cluster/apps/kube-prometheus-stack/kube-prometheus-stack.yaml
+++ b/k8s/local-cluster/apps/kube-prometheus-stack/kube-prometheus-stack.yaml
@@ -16,7 +16,7 @@ spec:
     path: ""
     chart: kube-prometheus-stack
     repoURL: https://prometheus-community.github.io/helm-charts
-    targetRevision: 48.1.2
+    targetRevision: 75.15.1
     helm:
       skipCrds: true
       values: |-

--- a/k8s/local-cluster/apps/loki/loki.yaml
+++ b/k8s/local-cluster/apps/loki/loki.yaml
@@ -16,7 +16,7 @@ spec:
     path: ""
     chart: loki-stack
     repoURL: https://grafana.github.io/helm-charts
-    targetRevision: 2.9.9
+    targetRevision: 2.10.2
     helm:
       values: |-
         loki:

--- a/k8s/local-cluster/apps/postgres/postgres.yaml
+++ b/k8s/local-cluster/apps/postgres/postgres.yaml
@@ -16,7 +16,7 @@ spec:
     path: ""
     chart: postgresql
     repoURL: https://charts.bitnami.com/bitnami
-    targetRevision: 12.2.5
+    targetRevision: 16.7.21
     helm:
       values: |-
         global:

--- a/k8s/local-cluster/argo/helmfile.yaml
+++ b/k8s/local-cluster/argo/helmfile.yaml
@@ -10,5 +10,6 @@ releases:
   - name: argo
     namespace: argo
     chart: argo/argo-cd
+    version: 8.2.5
     values:
       - values.yaml

--- a/k8s/manifests/promlens/promlens.yaml
+++ b/k8s/manifests/promlens/promlens.yaml
@@ -47,7 +47,7 @@ spec:
       serviceAccountName: promlens
       containers:
         - name: promlens
-          image: "prom/promlens:latest"
+          image: "prom/promlens:v0.3.0"
           imagePullPolicy: IfNotPresent
           ports:
             - name: http


### PR DESCRIPTION
### Changes:
- ingress-nginx: 4.5.2 → 4.13.0
- kube-prometheus-stack: 48.1.2 → 75.15.1
- loki-stack: 2.9.9 → 2.10.2
- postgresql: 12.2.5 → 16.7.21
- argo-cd: pin to 8.2.5
- promlens: latest → v0.3.0

### Additional info:

Upgraded all Kubernetes Helm charts to their latest versions and replaced latest image tags with specific versions for better reproducibility.